### PR TITLE
✨ Add header getter function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,14 +129,8 @@ const mergeOptions = <A, B>(
     params: merge(left.params, right.params),
   })
 
-const fnToPromise = <T>(fn: () => T | Promise<T>): Promise<T> => {
-  try {
-    return Promise.resolve(fn())
-  } catch (e) {
-    // pick up synchronous throws
-    Promise.reject(e)
-  }
-}
+const fnToPromise = <T>(fn: () => T | Promise<T>): Promise<T> =>
+  Promise.resolve().then(fn)
 
 function ResponseError(
   response: Response,


### PR DESCRIPTION
Hey there @exah, thanks for this lib. I'm currently working on a project that is using it. Been a breeze so far, only one minor snag: Mutating the instance properties feels a bit hacky.

this PR adds a way to use a function, so it can pick up values from closures (like redux stores, or some other state-management 😄) without the mutation.

Did a minimal implementation, we can improve it if this kind of feature is desired.

(originally I thought about using the `headers` property, but as the config is `extends RequestInit` it gets messy 😅)