### PR TITLE
:sparkles: pass in url and options to getHeader function

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -302,7 +302,13 @@ describe('Response', () => {
     const state = { token: 'none' }
     const api = YF.create({
       prefixUrl: 'https://example.com',
-      getHeaders: async () => {
+      headers: { 'x-static': 'static value' },
+      getHeaders: async (url, { method, headers }) => {
+        expect(url).toMatch(/example\.com\//)
+        expect(method).toBe('GET')
+        expect(headers).toHaveProperty('x-static', 'static value')
+        expect(headers).not.toHaveProperty('Authorization')
+        expect(headers).not.toHaveProperty('authorization')
         await new Promise((resolve) => setTimeout(resolve, 32))
         return { Authorization: `Bearer ${state.token}` }
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,10 @@ interface Options<T extends Payload> extends RequestInit {
   /** Request headers */
   headers?: Headers
   /** Request headers (async getter) */
-  getHeaders?: () => Headers | Promise<Headers>
+  getHeaders?: (
+    resource: string,
+    init: RequestInit
+  ) => Headers | Promise<Headers>
   /** Custom params serializer, default to `URLSearchParams` */
   serialize?(params: Options<T>['params']): URLSearchParams | string
   /** Response handler, must handle status codes or throw `ResponseError` */
@@ -198,7 +201,7 @@ function request<P extends Payload>(baseOptions: Options<P>): ResponseBody {
     // Running fetch in next tick allow us to set headers after creating promise
     setTimeout(() =>
       Promise.resolve()
-        .then(opts.getHeaders)
+        .then(() => opts.getHeaders ? opts.getHeaders(resource, opts) : undefined)
         .then((headers) => {
           assign(opts.headers, headers)
           return fetch(resource, opts)


### PR DESCRIPTION
hey there again 👋 😄

this is one expansion [over the last PR on the `getHeader` feature](https://github.com/exah/ya-fetch/pull/16)
found a case where it's best to know if some endpoint is exempt from some checks/locks,
moving this check inside the `getHeader` makes it cleaner, and avoids conflicting info from spreading through the default mutation method.

the alternative to this change (in my case) would be using 2 instances, one without the lock and one with the lock.

(in depth of the case in question: we lock api requests while token refresh is pending, as it can create a race condition when the old token has already been invalidated, but we haven't yet received the new one).